### PR TITLE
Fixed PDB_NAME for multitenant install

### DIFF
--- a/OracleDatabase/12.1/assets/entrypoint.sh
+++ b/OracleDatabase/12.1/assets/entrypoint.sh
@@ -107,7 +107,7 @@ create_database(){
 	gosu oracle bash -c 'echo -e "ALTER SYSTEM SET LOCAL_LISTENER='"'"'(ADDRESS = (PROTOCOL = TCP)(HOST = $(hostname))(PORT = 1521))'"'"' SCOPE=BOTH;\n ALTER SYSTEM REGISTER;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 	if [ $MULTITENANT == "true" ]; then
 		echo "Save open state of PDB."
-		gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE opdb1 OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
+		gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE ${PDB_NAME} OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 		echo "Remove APEX from CDB"
 		gosu oracle bash -c 'cd ${ORACLE_HOME}/apex.old; echo EXIT | /opt/sqlcl/bin/sql -s -l / as sysdba @apxremov_con.sql'
 	else

--- a/OracleDatabase/12.2/assets/entrypoint.sh
+++ b/OracleDatabase/12.2/assets/entrypoint.sh
@@ -104,7 +104,7 @@ create_database(){
 	gosu oracle bash -c 'echo -e "ALTER SYSTEM SET LOCAL_LISTENER='"'"'(ADDRESS = (PROTOCOL = TCP)(HOST = $(hostname))(PORT = 1521))'"'"' SCOPE=BOTH;\n ALTER SYSTEM REGISTER;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 	if [ $MULTITENANT == "true" ]; then
 		echo "Save open state of PDB."
-		gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE opdb1 OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
+		gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE ${PDB_NAME} OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 	fi;
 	echo "Applying data patches."
 	gosu oracle bash -c "cd ${ORACLE_HOME}/OPatch && (./datapatch -verbose)"

--- a/OracleDatabase/18.0/assets/entrypoint.sh
+++ b/OracleDatabase/18.0/assets/entrypoint.sh
@@ -108,7 +108,7 @@ create_database(){
 	gosu oracle bash -c 'echo -e "ALTER SYSTEM SET LOCAL_LISTENER='"'"'(ADDRESS = (PROTOCOL = TCP)(HOST = $(hostname))(PORT = 1521))'"'"' SCOPE=BOTH;\n ALTER SYSTEM REGISTER;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 	if [ $MULTITENANT == "true" ]; then
 		echo "Save open state of PDB."
-		gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE opdb1 OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
+		gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE ${PDB_NAME} OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 	fi;
 	echo "Applying data patches."
 	gosu oracle bash -c "cd ${ORACLE_HOME}/OPatch && (./datapatch -verbose) ; echo $?"

--- a/OracleDatabase/19.0/assets/entrypoint.sh
+++ b/OracleDatabase/19.0/assets/entrypoint.sh
@@ -70,7 +70,7 @@ create_database(){
 	gosu oracle bash -c 'echo -e "ALTER SYSTEM SET LOCAL_LISTENER='"'"'(ADDRESS = (PROTOCOL = TCP)(HOST = $(hostname))(PORT = 1521))'"'"' SCOPE=BOTH;\n ALTER SYSTEM REGISTER;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 	if [ $MULTITENANT == "true" ]; then
 		echo "Save open state of PDB."
-		gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE opdb1 OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
+		gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE ${PDB_NAME} OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 	fi;
 	echo "Applying data patches."
 	gosu oracle bash -c "cd ${ORACLE_HOME}/OPatch && (./datapatch -verbose) ; echo $?"

--- a/OracleDatabase/21.0/assets/entrypoint.sh
+++ b/OracleDatabase/21.0/assets/entrypoint.sh
@@ -71,7 +71,7 @@ create_database(){
 	echo "Configure listener."
 	gosu oracle bash -c 'echo -e "ALTER SYSTEM SET LOCAL_LISTENER='"'"'(ADDRESS = (PROTOCOL = TCP)(HOST = $(hostname))(PORT = 1521))'"'"' SCOPE=BOTH;\n ALTER SYSTEM REGISTER;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 	echo "Save open state of PDB."
-	gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE opdb1 OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
+	gosu oracle bash -c 'echo -e "ALTER PLUGGABLE DATABASE ${PDB_NAME} OPEN;\n ALTER PLUGGABLE DATABASE ${PDB_NAME} SAVE STATE;\n EXIT" | ${ORACLE_HOME}/bin/sqlplus -s -l / as sysdba'
 	echo "Applying data patches."
 	gosu oracle bash -c "cd ${ORACLE_HOME}/OPatch && (./datapatch -verbose) ; echo $?"
 	echo "Workaround for bug 25710407"


### PR DESCRIPTION
Setting PDB_NAME to value other than `opdb1` was causing issues with DB creation.